### PR TITLE
refactor: remove prettier/@typescript-eslint extension with v8 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -909,9 +909,9 @@
 			"integrity": "sha512-TKvuVmjsb9b31dAWDptI9vY2DlUGidhL2slX20GZtnWALRdoH8cjSOeLpDF2H+yU+wSVDL/Ni0oFWPaG8L8lWA=="
 		},
 		"eslint-config-prettier": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
-			"integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.0.0.tgz",
+			"integrity": "sha512-5EaAVPsIHu+grmm5WKjxUia4yHgRrbkd8I0ffqUSwixCPMVBrbS97UnzlEY/Q7OWo584vgixefM0kJnUfo/VjA==",
 			"dev": true
 		},
 		"eslint-plugin-prettier": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"@typescript-eslint/parser": "^4.11.1",
 		"codelyzer": "^6.0.1",
 		"eslint": "^7.16.0",
-		"eslint-config-prettier": "^7.1.0",
+		"eslint-config-prettier": "^8.0.0",
 		"eslint-plugin-prettier": "^3.3.0",
 		"eslint-plugin-vue": "^7.4.0",
 		"prettier": "^2.2.1",

--- a/prettier/jsx.js
+++ b/prettier/jsx.js
@@ -1,5 +1,5 @@
 const path = require('path');
 
 module.exports = {
-	extends: [path.join(__dirname, '..', 'jsx.js'), 'aqua/prettier/jsx', path.join(__dirname, 'prettier.js'), 'prettier'],
+	extends: [path.join(__dirname, '..', 'jsx.js'), 'aqua/prettier/jsx', path.join(__dirname, 'prettier.js')],
 };

--- a/prettier/jsx.js
+++ b/prettier/jsx.js
@@ -1,10 +1,5 @@
 const path = require('path');
 
 module.exports = {
-	extends: [
-		path.join(__dirname, '..', 'jsx.js'),
-		'aqua/prettier/jsx',
-		path.join(__dirname, 'prettier.js'),
-		'prettier/react',
-	],
+	extends: [path.join(__dirname, '..', 'jsx.js'), 'aqua/prettier/jsx', path.join(__dirname, 'prettier.js'), 'prettier'],
 };

--- a/prettier/prettier.js
+++ b/prettier/prettier.js
@@ -1,3 +1,3 @@
 module.exports = {
-	extends: ['aqua/prettier', 'prettier/@typescript-eslint'],
+	extends: ['aqua/prettier', 'prettier'],
 };

--- a/prettier/react.js
+++ b/prettier/react.js
@@ -1,10 +1,5 @@
 const path = require('path');
 
 module.exports = {
-	extends: [
-		path.join(__dirname, '..', 'react.js'),
-		'aqua/prettier/react',
-		path.join(__dirname, 'prettier.js'),
-		'prettier',
-	],
+	extends: [path.join(__dirname, '..', 'react.js'), 'aqua/prettier/react', path.join(__dirname, 'prettier.js')],
 };

--- a/prettier/react.js
+++ b/prettier/react.js
@@ -5,6 +5,6 @@ module.exports = {
 		path.join(__dirname, '..', 'react.js'),
 		'aqua/prettier/react',
 		path.join(__dirname, 'prettier.js'),
-		'prettier/react',
+		'prettier',
 	],
 };

--- a/prettier/vue.js
+++ b/prettier/vue.js
@@ -1,10 +1,5 @@
 const path = require('path');
 
 module.exports = {
-	extends: [
-		path.join(__dirname, '..', 'vue.js'),
-		'aqua/prettier/vue',
-		path.join(__dirname, 'prettier.js'),
-		'prettier/vue',
-	],
+	extends: [path.join(__dirname, '..', 'vue.js'), 'aqua/prettier/vue', path.join(__dirname, 'prettier.js'), 'prettier'],
 };

--- a/prettier/vue.js
+++ b/prettier/vue.js
@@ -1,5 +1,5 @@
 const path = require('path');
 
 module.exports = {
-	extends: [path.join(__dirname, '..', 'vue.js'), 'aqua/prettier/vue', path.join(__dirname, 'prettier.js'), 'prettier'],
+	extends: [path.join(__dirname, '..', 'vue.js'), 'aqua/prettier/vue', path.join(__dirname, 'prettier.js')],
 };


### PR DESCRIPTION
This PR removes the extension of `prettier/@typescript-eslint` as it was merged into `prettier` with the release of `eslint-config-prettier` v8

ref: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21