### PR TITLE
fix: use @typescript-eslint equivalent of no-duplicate-imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,8 @@ module.exports = {
 		'@typescript-eslint/lines-between-class-members': [2, 'always', { exceptAfterSingleLine: true }],
 		'no-dupe-class-members': 0,
 		'@typescript-eslint/no-dupe-class-members': 2,
+		'no-duplicate-imports': 0,
+		'@typescript-eslint/no-duplicate-imports': [2, { includeExports: false }],
 		'no-extra-semi': 0,
 		'@typescript-eslint/no-extra-semi': 2,
 		'no-useless-constructor': 0,


### PR DESCRIPTION
The eslint rule `no-duplicate-imports` gives unwanted errors with imports in ts as type imports are considered duplicates.
This cause the below code to error:
```ts
import { a } from "my-package";
import type { b } from "my-package";
```
This PR uses the `@typescript-eslint` version of this rule instead and disables the eslint version.